### PR TITLE
Use stackage lts snapshot instead of nightly

### DIFF
--- a/buildprep
+++ b/buildprep
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 mv stack.yaml stack-old.yaml
-stack --resolver=lts-3.14 runghc genCabal.hs --package cartel --install-ghc > pinchot.cabal
+stack genCabal.hs > pinchot.cabal
 mv stack-old.yaml stack.yaml

--- a/genCabal.hs
+++ b/genCabal.hs
@@ -1,5 +1,5 @@
 #!/usr/bin/env stack
--- stack --resolver=lts-3.14 --install-ghc runghc --package=cartel
+-- stack --resolver=lts-5.1 --install-ghc runghc --package=cartel
 
 module Main where
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,7 +1,7 @@
 # For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
 
 # Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: nightly-2016-01-26
+resolver: lts-5.1
 
 # Local packages, usually specified by relative directory name
 packages:


### PR DESCRIPTION
An lts snapshot  is supposed to be more stable and more likely to be already
found in other users' cache.

Also made the script snapshot version the same as the stack.yaml snapshot.